### PR TITLE
fix: bytes encoding and buffer convertions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/sdkgen/browser-runtime#readme",
   "devDependencies": {
     "@types/jest": "^24.0.23",
+    "@types/node": "^13.7.0",
     "jest": "^24.9.0",
     "ts-jest": "^24.2.0",
     "typescript": "^3.7.3"

--- a/src/encode-decode.ts
+++ b/src/encode-decode.ts
@@ -3,12 +3,11 @@ import { TypeDescription, TypeTable } from "./ast";
 const simpleStringTypes = ["string", "cep", "email", "phone", "safehtml", "xml"];
 const simpleTypes = ["json", "bool", "hex", "uuid", "base64", "url", "int", "uint", "float", "money", "void", "latlng", ...simpleStringTypes];
 
-function bufferToBase64(buffer: ArrayBuffer) {
-    return btoa(String.fromCharCode(...new Uint8Array(buffer)));
+function bufferToBase64(buffer: Buffer) {
+    return buffer.toString("base64");
 }
-
 function base64ToBuffer(str: string) {
-    return new Uint8Array([...atob(str)].map(char => char.charCodeAt(0))).buffer;
+    return Buffer.from(str, "base64");
 }
 function simpleEncodeDecode(path: string, type: string, value: any) {
     if (typeof value === "bigint") {
@@ -121,7 +120,7 @@ export function encode(typeTable: TypeTable, path: string, type: TypeDescription
     } else if (simpleTypes.indexOf(type) >= 0) {
         return simpleEncodeDecode(path, type, value);
     } else if (type === "bytes") {
-        if (!(value instanceof ArrayBuffer)) {
+        if (!(value instanceof Buffer)) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
         return bufferToBase64(value);


### PR DESCRIPTION
sdkgen's `bytes` type gets converted to a `Buffer` type by the typescript-generator, which is later expected to be an `ArrayBuffer` as seeing on line 123. This causes the browser-runtime to throw an error every time the client tries to pass the expected type, a `Buffer`.

The actual buffer conversions are throwing a `Maximum call stack size exceeded`. Since the browser-runtime is supposed to run on top of some Node based application, using Node's `Buffer` methods shouldn't be a problem.